### PR TITLE
Define WebpackManifestFunctions extension

### DIFF
--- a/src/WebpackManifestFunctions.php
+++ b/src/WebpackManifestFunctions.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace CarterDigital\TwigExtensions;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Defines a function to get the public path of a webpack asset from
+ * the asset manifest.
+ *
+ * This should be used in conjunction with WebpackManifestPlugin.
+ *
+ * See: https://github.com/shellscape/webpack-manifest-plugin
+ */
+class WebpackManifestFunctions extends AbstractExtension
+{
+    /**
+     * The full path to the manifest.json to check for asset paths.
+     *
+     * @var str
+     */
+    protected $manifestFilepath;
+
+    /**
+     * Provide path to manifest json file and verify that it exists.
+     *
+     * @param string $manifestFilepath
+     *
+     * @throws InvalidArgumentException   Throws if no path to manifest file has been provided.
+     * @throws RuntimeException           Throws if the manifest file doesn't exist.
+     */
+    public function __construct(string $manifestFilepath)
+    {
+        if (empty($manifestFilepath)) {
+            throw new \InvalidArgumentException("Manifest file path cannot be null or empty");
+        };
+
+        if (!file_exists($manifestFilepath)) {
+            throw new \RuntimeException("The manifest.json file could not be found at '$manifestFilepath'!\n You might need to run a front end asset build, or check that the supplied file path to manifest is correct.");
+        }
+
+        $this->manifestFilepath = $manifestFilepath;
+    }
+
+    /**
+     * Return extension name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'carter-digital/webpack-manifest-functions';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('manifestFile', [$this, 'getFile'])
+        ];
+    }
+
+    /**
+     * Check manifest for asset with `$handle` and return its public path.
+     *
+     * @param string $handle
+     * @return string|bool
+     *
+     * @throws RuntimeException   Throws if manifest file doesn't have a
+     *                            corresponding entry for `$handle`.
+     */
+    public function getFile($handle)
+    {
+        $file = file_get_contents(strval($this->manifestFilepath));
+        $manifest = json_decode($file, true);
+
+        if (!array_key_exists($handle, $manifest)) {
+            throw new \RuntimeException("The manifest.json file does not contain a reference to '$handle'.\n Verify that '$this->manifestFilepath' contains an entry for '$handle'.");
+        }
+
+        return $manifest[$handle];
+    }
+}

--- a/tests/WebpackManifestFunctions.php
+++ b/tests/WebpackManifestFunctions.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace CarterDigital\TwigExtensions\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+use CarterDigital\TwigExtensions\WebpackManifestFunctions;
+
+class WebpackManifestFunctionsTest extends TestCase
+{
+    use Utils\TestHelpers;
+
+    /**
+     * Get the tested extension
+     *
+     * @return \Twig\Extension\AbstractExtension;
+     */
+    protected function getExtension()
+    {
+
+        return new WebpackManifestFunctions(__DIR__ . '/utils/manifest.json');
+    }
+
+    /**
+     * If an empty filepath is passed, we should raise
+     * an InvalidArgumentException.
+     *
+     * @return void
+     */
+    public function testEmptyManifestFilepath()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new WebpackManifestFunctions('');
+    }
+
+    /**
+     * If manifest file cannot be found we should raise
+     * a RuntimeException.
+     *
+     * @return void
+     */
+    public function testMissingManifestJson()
+    {
+        $this->expectException(\RuntimeException::class);
+        new WebpackManifestFunctions('does/not/exist.json');
+    }
+
+    /**
+     * If manifest doesn't contain entry for $handle we
+     * should raise a RuntimeException.
+     *
+     * @return void
+     */
+    public function testNoEntryInManifestJson()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->getExtension()->getFile('not-found.css');
+    }
+
+    /**
+     * If manifest contains an entry for $handle we
+     * should return its value.
+     *
+     * @return string
+     */
+    public function testIsManifestFile()
+    {
+
+        $this->assertRender('/dist/app.css', $this->render('{{ manifestFile("app.css") }}'));
+    }
+}

--- a/tests/utils/manifest.json
+++ b/tests/utils/manifest.json
@@ -1,0 +1,4 @@
+{
+  "app.js": "/dist/app.js",
+  "app.css": "/dist/app.css"
+}


### PR DESCRIPTION
- Pass in path to Webpack `manifest.json` file
- Use `manifestFile` twig function to get the public path of an asset from the manifest.

**Note:**  Refer to `tests/utils/manifest.json` for testing and usage.