### PR TITLE
Update Twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "twig/twig": "~2.14.3",
+        "twig/twig": "~2.15.3",
         "php": ">=7.2.19",
         "vlucas/phpdotenv": "^3.0"
     },


### PR DESCRIPTION
Update Twig to make it work with Craft CMS 3.7.55.3+